### PR TITLE
feat(ai): add detailed multi-line commit message generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ aic-commit --config ./my-config.json
 | `--config <path>`             | Path to custom configuration file              |
 | `--model <model>`             | AI model to use (overrides config)             |
 | `--provider <provider>`       | AI provider: openai, anthropic, gemini         |
-| `--max-tokens <number>`       | Maximum tokens for AI response (1-4000)        |
+| `--max-tokens <number>`       | Maximum tokens for AI response (1-8000)        |
 | `--choices <number>`          | Generate multiple options to choose from (2-5) |
+| `--detailed`                  | Generate detailed multi-line commit messages   |
 | `--dry-run`                   | Generate message without committing            |
 | `-v, --verbose`               | Show detailed progress information             |
 | `--debug`                     | Show debug information                         |
@@ -358,6 +359,67 @@ Select option (1-3): 2
 aic-commit --choices 3 --dry-run --json
 ```
 
+### Detailed Commit Messages
+
+Generate comprehensive multi-line commit messages with bullet-point explanations:
+
+```bash
+# Generate detailed commit with explanations
+aic-commit --detailed --max-tokens 400
+
+# Combine detailed with multiple choices
+aic-commit --detailed --choices 3 --max-tokens 600
+
+# Preview detailed format
+aic-commit --detailed --dry-run --max-tokens 400
+```
+
+**Example Output:**
+
+```
+feat(auth): implement user authentication system
+
+- add login and signup forms with validation
+- integrate JWT token management for sessions
+- create password reset functionality via email
+- implement role-based access control middleware
+- add user profile management endpoints
+```
+
+**Detailed with Multiple Choices:**
+
+```
+Choose your commit message:
+1. feat(auth): implement user authentication system
+
+- add login and signup forms with validation
+- integrate JWT token management for sessions
+- create password reset functionality via email
+- implement role-based access control middleware
+
+2. feat(security): create user authentication features
+
+- design secure login flow with input validation
+- develop JWT-based session management system
+- build password recovery via email verification
+- add user role permissions and access control
+
+3. feat(backend): develop authentication infrastructure
+
+- create user registration and login endpoints
+- implement secure session handling with JWT
+- add password reset email functionality
+- build role-based permission system
+
+Select option (1-3): _
+```
+
+**Token Requirements for Detailed Commits:**
+
+- **Simple detailed**: 300-500 tokens
+- **Detailed + choices**: 500-800 tokens
+- **Complex projects**: 600-1000 tokens
+
 ### Troubleshooting Token Limits
 
 If you encounter "MAX_TOKENS" errors, especially with Gemini:
@@ -369,10 +431,14 @@ aic-commit --max-tokens 300
 # For complex changes, use even higher limits
 aic-commit --max-tokens 500
 
+# For detailed commits, use higher token limits
+aic-commit --detailed --max-tokens 600
+
 # Provider-specific recommendations:
 # OpenAI: 150-200 tokens (efficient)
 # Anthropic: 150-250 tokens (balanced)
 # Gemini: 300-400 tokens (needs more tokens to complete responses)
+# Detailed commits: 400-800 tokens (depending on complexity)
 ```
 
 ## API Reference

--- a/src/ai/providers/anthropic.ts
+++ b/src/ai/providers/anthropic.ts
@@ -20,29 +20,29 @@ export class AnthropicProvider extends BaseAIProvider {
   async generateCommitMessage(
     diff: string,
     description?: string,
-    choices?: number
+    choices?: number,
+    detailed?: boolean
   ): Promise<string> {
     try {
       const completion = await this.client.completions.create({
         model: this.model,
         max_tokens_to_sample: this.maxTokens,
         temperature: this.temperature,
-        prompt: `${this.createSystemPrompt(choices)}\n\nHuman: ${this.createUserPrompt(diff, description)}\n\nAssistant:`,
+        prompt: `${this.createSystemPrompt(choices, detailed)}\n\nHuman: ${this.createUserPrompt(diff, description)}\n\nAssistant:`,
       });
 
       if (!completion.completion) {
         throw new Error('Anthropic returned empty response');
       }
 
-      // If multiple choices requested, parse them and return as formatted string
-      if (choices && choices > 1) {
-        const parsedChoices = this.parseMultipleChoices(completion.completion);
-        return parsedChoices
-          .map((choice, index) => `${index + 1}. ${choice}`)
-          .join('\n');
+      // Handle detailed commits or multiple choices
+      if (detailed || (choices && choices > 1)) {
+        // For detailed commits, return the full response as-is
+        // For multiple choices, also return full response (contains numbered options)
+        return completion.completion.trim();
       }
 
-      // Single choice - use original post-processing
+      // Single choice, non-detailed - use original post-processing
       return this.postProcessMessage(completion.completion);
     } catch (error) {
       if (error instanceof Error) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const ConfigSchema = z.object({
   provider: z.enum(['openai', 'anthropic', 'gemini']).default('openai'),
   model: z.string().optional(),
-  maxTokens: z.number().min(1).max(4000).default(150),
+  maxTokens: z.number().min(1).max(8000).default(150),
   temperature: z.number().min(0).max(2).default(0.3),
   excludePatterns: z.array(z.string()).default([]),
   defaultDescription: z.string().optional(),

--- a/src/git/commit.ts
+++ b/src/git/commit.ts
@@ -93,23 +93,79 @@ export function validateConventionalCommit(message: string): {
  */
 export function formatCommitMessage(message: string): string {
   // Remove excessive whitespace and ensure proper formatting
-  const lines = message
-    .trim()
-    .split('\n')
-    .map((line) => line.trim());
+  const lines = message.trim().split('\n');
 
-  // Remove empty lines at the beginning and end
-  while (lines.length > 0 && lines[0] === '') {
-    lines.shift();
-  }
-  while (lines.length > 0 && lines[lines.length - 1] === '') {
-    lines.pop();
-  }
+  // Check if this is a detailed commit (has bullets after the first line)
+  const isDetailedCommit = lines.some(
+    (line, index) => index > 0 && line.trim().startsWith('-')
+  );
 
-  // Ensure the first line doesn't end with a period
-  if (lines.length > 0 && lines[0] && lines[0].endsWith('.')) {
-    lines[0] = lines[0].slice(0, -1);
-  }
+  if (isDetailedCommit) {
+    // For detailed commits, preserve structure but clean up lines
+    const cleanedLines = lines.map((line) => line.trimEnd());
 
-  return lines.join('\n');
+    // Remove empty lines at the beginning and end only
+    while (
+      cleanedLines.length > 0 &&
+      cleanedLines[0] &&
+      cleanedLines[0].trim() === ''
+    ) {
+      cleanedLines.shift();
+    }
+    while (
+      cleanedLines.length > 0 &&
+      cleanedLines[cleanedLines.length - 1] &&
+      cleanedLines[cleanedLines.length - 1]!.trim() === ''
+    ) {
+      cleanedLines.pop();
+    }
+
+    // Ensure there's a blank line between header and bullets if not present
+    if (
+      cleanedLines.length >= 2 &&
+      cleanedLines[0] &&
+      cleanedLines[0].trim() !== '' &&
+      cleanedLines[1] &&
+      cleanedLines[1].trim().startsWith('-') &&
+      cleanedLines[1].trim() !== ''
+    ) {
+      cleanedLines.splice(1, 0, '');
+    }
+
+    // Ensure the first line doesn't end with a period
+    if (
+      cleanedLines.length > 0 &&
+      cleanedLines[0] &&
+      cleanedLines[0].endsWith('.')
+    ) {
+      cleanedLines[0] = cleanedLines[0].slice(0, -1);
+    }
+
+    return cleanedLines.join('\n');
+  } else {
+    // For simple commits, use original logic
+    const cleanedLines = lines.map((line) => line.trim());
+
+    // Remove empty lines at the beginning and end
+    while (cleanedLines.length > 0 && cleanedLines[0] === '') {
+      cleanedLines.shift();
+    }
+    while (
+      cleanedLines.length > 0 &&
+      cleanedLines[cleanedLines.length - 1] === ''
+    ) {
+      cleanedLines.pop();
+    }
+
+    // Ensure the first line doesn't end with a period
+    if (
+      cleanedLines.length > 0 &&
+      cleanedLines[0] &&
+      cleanedLines[0].endsWith('.')
+    ) {
+      cleanedLines[0] = cleanedLines[0].slice(0, -1);
+    }
+
+    return cleanedLines.join('\n');
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,8 @@ export interface AIProvider {
   generateCommitMessage(
     diff: string,
     description?: string,
-    choices?: number
+    choices?: number,
+    detailed?: boolean
   ): Promise<string>;
   validateConfig(): boolean;
 }
@@ -30,6 +31,7 @@ export interface CLIOptions {
   provider?: 'openai' | 'anthropic' | 'gemini';
   maxTokens?: number;
   choices?: number;
+  detailed?: boolean;
   dryRun?: boolean;
   verbose?: boolean;
   debug?: boolean;


### PR DESCRIPTION
- introduce a new `--detailed` CLI flag to enable the feature
- create new system prompts for generating detailed, multi-line commits
- implement a response parser to handle multi-line choices
- refactor commit message formatting to support detailed structure
- increase the maximum token limit from 4000 to 8000
- update README with usage instructions and examples for the new feature